### PR TITLE
Show focus/backdrop theme differences on CSD windows 

### DIFF
--- a/include/compiz-core.h
+++ b/include/compiz-core.h
@@ -2599,7 +2599,6 @@ struct _CompWindow {
     Bool	      damaged;
     Bool	      redirected;
     Bool	      managed;
-    Bool	      focused;
     Bool	      unmanaging;
     Bool	      bindFailed;
     Bool	      overlayWindow;

--- a/include/compiz-core.h
+++ b/include/compiz-core.h
@@ -143,6 +143,7 @@ typedef struct _CompWalker        CompWalker;
 #define CompWindowStateBelowMask	    (1 << 10)
 #define CompWindowStateDemandsAttentionMask (1 << 11)
 #define CompWindowStateDisplayModalMask	    (1 << 12)
+#define CompWindowStateFocusedMask	    (1 <<  13)
 
 #define MAXIMIZE_STATE (CompWindowStateMaximizedHorzMask | \
 			CompWindowStateMaximizedVertMask)
@@ -939,6 +940,7 @@ struct _CompDisplay {
 
     Atom winStateAtom;
     Atom winStateModalAtom;
+    Atom winStateFocusedAtom;
     Atom winStateStickyAtom;
     Atom winStateMaximizedVertAtom;
     Atom winStateMaximizedHorzAtom;
@@ -2597,6 +2599,7 @@ struct _CompWindow {
     Bool	      damaged;
     Bool	      redirected;
     Bool	      managed;
+    Bool	      focused;
     Bool	      unmanaging;
     Bool	      bindFailed;
     Bool	      overlayWindow;

--- a/include/compiz-core.h
+++ b/include/compiz-core.h
@@ -129,7 +129,8 @@ typedef struct _CompWalker        CompWalker;
 #define NO_FOCUS_MASK (CompWindowTypeDesktopMask | \
 		       CompWindowTypeDockMask    | \
 		       CompWindowTypeSplashMask)
-
+#define APPEAR_FOCUSED_MASK (CompWindowTypeDockMask | \
+		       CompWindowTypeSplashMask)
 #define CompWindowStateModalMask	    (1 <<  0)
 #define CompWindowStateStickyMask	    (1 <<  1)
 #define CompWindowStateMaximizedVertMask    (1 <<  2)

--- a/src/display.c
+++ b/src/display.c
@@ -2072,6 +2072,8 @@ addDisplay (const char *name)
     d->winStateAtom		    = XInternAtom (dpy, "_NET_WM_STATE", 0);
     d->winStateModalAtom	    =
 	XInternAtom (dpy, "_NET_WM_STATE_MODAL", 0);
+    d->winStateFocusedAtom	    =
+	XInternAtom (dpy, "_NET_WM_STATE_FOCUSED", 0);
     d->winStateStickyAtom	    =
 	XInternAtom (dpy, "_NET_WM_STATE_STICKY", 0);
     d->winStateMaximizedVertAtom    =

--- a/src/event.c
+++ b/src/event.c
@@ -2182,9 +2182,9 @@ handleEvent (CompDisplay *d,
     case CirculateRequest:
 	break;
     case FocusIn:
+    w = findTopLevelWindowAtDisplay (d, event->xfocus.window);
 	if (event->xfocus.mode != NotifyGrab)
 	{
-	    w = findTopLevelWindowAtDisplay (d, event->xfocus.window);
 	    if (w && w->managed)
 	    {
 		unsigned int state = w->state;
@@ -2203,8 +2203,7 @@ handleEvent (CompDisplay *d,
 		}
 
 		state &= ~CompWindowStateDemandsAttentionMask;
-        /*Set the focussed window state atom */
-        changeWindowState (w, w->state | CompWindowStateFocusedMask);
+		changeWindowState (w, state);
 	    }
 	    else
 	    {
@@ -2219,14 +2218,32 @@ handleEvent (CompDisplay *d,
 		    {
 			/* we don't want the root window to get focus */
 			focusDefaultWindow (s);
-            /*Set the focussed window state atom */
-            changeWindowState (w, w->state);
 		    }
 		}
 	    }
 
 	    if (d->nextActiveWindow == event->xfocus.window)
 		d->nextActiveWindow = None;
+	}
+
+	if (w)
+	{
+		CompWindow *tmp;
+		for (s = d->screens; s; s = s->next)
+		{
+			if (s)
+			{
+				for (tmp = s->windows; tmp; tmp = tmp->next)
+				{
+					/* Unset focused bit for all windows */
+					if (tmp->state & CompWindowStateFocusedMask)
+						changeWindowState (tmp, tmp->state & ~CompWindowStateFocusedMask);
+				}
+			}
+		}
+
+		/* Set the focused window state atom */
+		changeWindowState (w, w->state | CompWindowStateFocusedMask);
 	}
 	break;
     case EnterNotify:

--- a/src/event.c
+++ b/src/event.c
@@ -2097,6 +2097,9 @@ handleEvent (CompDisplay *d,
 	{
 	    XMapWindow (d->display, event->xmaprequest.window);
 	}
+    /*Focus all docks and panels*/
+    if (w->type & APPEAR_FOCUSED_MASK)
+         changeWindowState (w, w->state | CompWindowStateFocusedMask);
 	break;
     case ConfigureRequest:
 	w = findWindowAtDisplay (d, event->xconfigurerequest.window);

--- a/src/event.c
+++ b/src/event.c
@@ -2203,7 +2203,8 @@ handleEvent (CompDisplay *d,
 		}
 
 		state &= ~CompWindowStateDemandsAttentionMask;
-		changeWindowState (w, state);
+        /*Set the focussed window state atom */
+        changeWindowState (w, w->state | CompWindowStateFocusedMask);
 	    }
 	    else
 	    {
@@ -2218,6 +2219,8 @@ handleEvent (CompDisplay *d,
 		    {
 			/* we don't want the root window to get focus */
 			focusDefaultWindow (s);
+            /*Set the focussed window state atom */
+            changeWindowState (w, w->state);
 		    }
 		}
 	    }

--- a/src/event.c
+++ b/src/event.c
@@ -2226,6 +2226,7 @@ handleEvent (CompDisplay *d,
 		d->nextActiveWindow = None;
 	}
 
+
 	if (w)
 	{
 		CompWindow *tmp;
@@ -2235,8 +2236,8 @@ handleEvent (CompDisplay *d,
 			{
 				for (tmp = s->windows; tmp; tmp = tmp->next)
 				{
-					/* Unset focused bit for all windows */
-					if (tmp->state & CompWindowStateFocusedMask)
+					/* Unset focused bit for all windows except type dock and splash */
+					if ((tmp->state & CompWindowStateFocusedMask) && !(tmp->type & APPEAR_FOCUSED_MASK))
 						changeWindowState (tmp, tmp->state & ~CompWindowStateFocusedMask);
 				}
 			}

--- a/src/screen.c
+++ b/src/screen.c
@@ -1250,6 +1250,7 @@ addSupportedAtoms (CompScreen   *s,
 
     atoms[count++] = d->winStateAtom;
     atoms[count++] = d->winStateModalAtom;
+    atoms[count++] = d->winStateFocusedAtom;
     atoms[count++] = d->winStateStickyAtom;
     atoms[count++] = d->winStateMaximizedVertAtom;
     atoms[count++] = d->winStateMaximizedHorzAtom;

--- a/src/window.c
+++ b/src/window.c
@@ -595,6 +595,8 @@ windowStateMask (CompDisplay *display,
 	return CompWindowStateDemandsAttentionMask;
     else if (state == display->winStateDisplayModalAtom)
 	return CompWindowStateDisplayModalMask;
+    else if (state == display->winStateFocusedAtom)
+	return CompWindowStateFocusedMask;
 
     return 0;
 }
@@ -604,6 +606,8 @@ windowStateFromString (const char *str)
 {
     if (strcasecmp (str, "modal") == 0)
 	return CompWindowStateModalMask;
+    else if (strcasecmp (str, "focused") == 0)
+	return CompWindowStateFocusedMask;
     else if (strcasecmp (str, "sticky") == 0)
 	return CompWindowStateStickyMask;
     else if (strcasecmp (str, "maxvert") == 0)
@@ -667,6 +671,8 @@ setWindowState (CompDisplay  *display,
 
     if (state & CompWindowStateModalMask)
 	data[i++] = display->winStateModalAtom;
+    if (state & CompWindowStateFocusedMask)
+	data[i++] = display->winStateFocusedAtom;
     if (state & CompWindowStateStickyMask)
 	data[i++] = display->winStateStickyAtom;
     if (state & CompWindowStateMaximizedVertMask)
@@ -2078,6 +2084,7 @@ addWindow (CompScreen *screen,
     w->damaged    = FALSE;
     w->redirected = TRUE;
     w->managed    = FALSE;
+    w->focused    = FALSE;
     w->unmanaging = FALSE;
     w->bindFailed = FALSE;
 

--- a/src/window.c
+++ b/src/window.c
@@ -2084,7 +2084,6 @@ addWindow (CompScreen *screen,
     w->damaged    = FALSE;
     w->redirected = TRUE;
     w->managed    = FALSE;
-    w->focused    = FALSE;
     w->unmanaging = FALSE;
     w->bindFailed = FALSE;
 


### PR DESCRIPTION
Fix https://github.com/compiz-reloaded/compiz/issues/71
 by supporting _NET_WM_STATE_FOCUSED 