### PR TITLE
decorator: kill bashisms

### DIFF
--- a/plugins/compiz-decorator
+++ b/plugins/compiz-decorator
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (c) 2015 Sorokin Alexei <sor.alexei@meowr.ru>
 # Copyright (c) 2007 CyberOrg <cyberorg@cyberorg.info>
@@ -15,13 +15,13 @@
 #
 # You should have received a copy of the GNU General Public License.
 #
-# Contributions by: crdlb
+# Contributions by: crdlb, dankamongmen
 #
 
 
 # Prints the arguments if verbose.
 verbose() {
-    if [[ "$VERBOSE" == 'yes' ]]; then
+    if [ "$VERBOSE" = 'yes' ]; then
         printf "$*" >&2
     fi
 }


### PR DESCRIPTION
Compiz invokes compiz-decorator with `sh -c`. On most Debian-derived machines, this will result in calling `/bin/sh` as linked to `dash`, which vomits on these bashisms. Since we're now POSIX-safe, go ahead and explicitly call for `/bin/sh`.