### PR TITLE
[bug] Button bindings for command0 turn out wrong.

### DIFF
--- a/TODO
+++ b/TODO
@@ -11,6 +11,7 @@ General:
 
 * Multi-screen support
 
+* bug with button settings for command0
 
 KDE:
 


### PR DESCRIPTION
I recently installed version 8.18.0. Thanks for putting all the work in. 

I discovered what looks like a bug. When using ccsm and setting the button bindings for command0 and selecting left edge, top left, and buttom left + plus button3 I also get top edge and buttom edge. When I do the same for say, command7 it works as it should. 

@soreau: Where should I start to look in order to provide a bug fix for this? 

The commit below is just because I wasn't able to create an issue.
